### PR TITLE
Update ASP Calling Convention and `handle_*body` functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_am_lib"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 repository = "https://github.com/ku-sldg/rust-am-lib"
 [dependencies]


### PR DESCRIPTION
The ASP calling convention has changed to be that they launch, read from STDIN and then process (rather than previously they read arguments via command line).

This PR changes the convention to the new version.

Compatible with `rocq-cvm` version 0.2.0